### PR TITLE
Support client secrets

### DIFF
--- a/src/main/java/com/amazonaws/sample/cognitoui/CognitoHelper.java
+++ b/src/main/java/com/amazonaws/sample/cognitoui/CognitoHelper.java
@@ -31,6 +31,7 @@ import java.util.*;
 class CognitoHelper {
     private String POOL_ID;
     private String CLIENTAPP_ID;
+    private String CLIENT_SECRET;
     private String FED_POOL_ID;
     private String CUSTOMDOMAIN;
     private String REGION;
@@ -49,6 +50,7 @@ class CognitoHelper {
             // Read the property values
             POOL_ID = prop.getProperty("POOL_ID");
             CLIENTAPP_ID = prop.getProperty("CLIENTAPP_ID");
+            CLIENT_SECRET = prop.getProperty("CLIENT_SECRET");
             FED_POOL_ID = prop.getProperty("FED_POOL_ID");
             CUSTOMDOMAIN = prop.getProperty("CUSTOMDOMAIN");
             REGION = prop.getProperty("REGION");
@@ -165,7 +167,7 @@ class CognitoHelper {
      * @return returns the JWT token after the validation
      */
     String ValidateUser(String username, String password) {
-        AuthenticationHelper helper = new AuthenticationHelper(POOL_ID, CLIENTAPP_ID, "");
+        AuthenticationHelper helper = new AuthenticationHelper(POOL_ID, CLIENTAPP_ID, CLIENT_SECRET);
         return helper.PerformSRPAuthentication(username, password);
     }
 

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,5 +1,6 @@
 POOL_ID=us-east-1_7jaipg4Cp
 CLIENTAPP_ID=5tljfddhsb6knmqd8jmhra2cp
+CLIENT_SECRET=
 FED_POOL_ID=us-east-1:50b30d3a-57c2-4771-8fdd-f2a12469a94a
 CUSTOMDOMAIN=ioe898d
 REGION=us-east-1


### PR DESCRIPTION
Read client secret from the CLIENT_SECRET property value and compute the SECRET_HASH value accordingly.
Fix existing code to include the SECRET_HASH value in both requests sent to cognito.

*Issue #3 

*Description of changes:
It took me quite some time to figure out what was missing in the aws-cognito-java-desktop-app in order to be able to use a cognito pool with a client secret. There is some commented out code to support the SECRET_HASH, but it is incomplete. I finally found part of the missing code in issue #3.
In this pull request I made a working example where the CLIENT_SECRET can be read from the file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
